### PR TITLE
Remove Open Graph meta partial and its inclusion

### DIFF
--- a/layouts/partials/head/custom.html
+++ b/layouts/partials/head/custom.html
@@ -3,7 +3,3 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | relURL }}">
 <link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
 <link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
-
-{{ if .IsPage }}
-{{ partial "ogp.html" . }}
-{{ end }}

--- a/layouts/partials/ogp.html
+++ b/layouts/partials/ogp.html
@@ -1,8 +1,0 @@
-<meta property="og:type" content="article">
-<meta property="og:title" content="{{ .Title }}">
-<meta property="og:url" content="{{ .Permalink }}">
-<meta property="og:site_name" content="{{ .Site.Title }}">
-
-{{ with .Params.tags }}
-<meta property="og:description" content="{{ delimit . ", " }}">
-{{ end }}


### PR DESCRIPTION
### Motivation
- Remove OGP meta output generated by the `ogp.html` partial to simplify the page head and avoid emitting incorrect or undesired Open Graph metadata.

### Description
- Deleted `layouts/partials/ogp.html` and removed the conditional inclusion `{{ if .IsPage }}{{ partial "ogp.html" . }}{{ end }}` from `layouts/partials/head/custom.html`, leaving only favicon and manifest links.

### Testing
- Built the site with `hugo` and verified the generated HTML no longer contains the Open Graph meta tags and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d1ae9450833292fa245aaf36359a)