### PR TITLE
Remove cacheDir configuration from Hugo config

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -2,7 +2,6 @@ baseURL = 'https://rin2yh.github.io/blog/'
 languageCode = 'ja'
 title = 'りんりんのメモ帳'
 theme = 'stack-liquid-glass'
-cacheDir = '.hugo_cache'
 
 # Set hasCJKLanguage to true if DefaultContentLanguage is in [zh-cn ja ko]
 # This will make .Summary and .WordCount behave correctly for CJK languages.


### PR DESCRIPTION
## Summary
Removed the explicit `cacheDir` configuration from the Hugo site configuration file.

## Changes
- Removed `cacheDir = '.hugo_cache'` from `config/_default/hugo.toml`

## Details
This change allows Hugo to use its default cache directory behavior instead of explicitly specifying `.hugo_cache`. This simplifies the configuration and may improve compatibility with Hugo's default caching mechanisms.

https://claude.ai/code/session_01BVvu4KDdYdwmCaxr7SV3Sc