### PR TITLE
feat: NFC共有用のリンクまとめページを追加 (/page/links/)

### DIFF
--- a/assets/icons/book.svg
+++ b/assets/icons/book.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z"/></svg>

--- a/assets/icons/chevron-right.svg
+++ b/assets/icons/chevron-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>

--- a/content/page/links/index.md
+++ b/content/page/links/index.md
@@ -2,11 +2,11 @@
 title: "Links"
 slug: "links"
 layout: "links"
-description: "りんりんのリンク集 / NFC・QRから飛んできた人向け"
+description: "りんりんの SNS・ブログなど各種リンク。NFC・QR から飛んできた方へ"
 readingTime: false
 profile:
   name: "りんりん"
-  bio: "ブログ / GitHub / SNS のリンク集です"
+  bio: "ここから各所へどうぞ。ブログ・GitHub・SNS など"
   avatar: "image/avatar.webp"
 links:
   - name: "ブログを読む"

--- a/content/page/links/index.md
+++ b/content/page/links/index.md
@@ -1,0 +1,42 @@
+---
+title: "Links"
+slug: "links"
+layout: "links"
+description: "りんりんのリンク集 / NFC・QRから飛んできた人向け"
+readingTime: false
+profile:
+  name: "りんりん"
+  bio: "ブログ / GitHub / SNS のリンク集です"
+  avatar: "image/avatar.webp"
+links:
+  - name: "ブログを読む"
+    url: "/"
+    icon: "book"
+    external: false
+  - name: "自己紹介 / About"
+    url: "/page/about/"
+    icon: "user"
+    external: false
+  - name: "GitHub"
+    url: "https://github.com/rin2yh"
+    icon: "brand-github"
+    external: true
+  - name: "Twitter / X"
+    url: "https://x.com/rin2yh"
+    icon: "brand-twitter"
+    external: true
+  - name: "Zenn"
+    url: "https://zenn.dev/rinrin_yuuki"
+    icon: "zenn-logo"
+    external: true
+  - name: "Speaker Deck"
+    url: "https://speakerdeck.com/rin2yh"
+    icon: "speakerdeck"
+    external: true
+# メニューに表示する場合は以下のコメントを外す
+# menu:
+#   main:
+#     weight: 5
+#     params:
+#       icon: link
+---

--- a/layouts/page/links.html
+++ b/layouts/page/links.html
@@ -1,0 +1,103 @@
+{{ define "main" }}
+<section class="links-page">
+  <header class="links-profile">
+    {{ with .Params.profile.avatar }}
+      {{ with resources.Get . }}
+        <img class="links-avatar" src="{{ .RelPermalink }}" alt="" />
+      {{ end }}
+    {{ end }}
+    <h1 class="links-name">{{ .Params.profile.name | default site.Title }}</h1>
+    {{ with .Params.profile.bio }}<p class="links-bio">{{ . }}</p>{{ end }}
+  </header>
+
+  <nav class="links-list" aria-label="リンク一覧">
+    {{ range .Params.links }}
+      <a class="link-card"
+         href="{{ if .external }}{{ .url | safeURL }}{{ else }}{{ .url | relLangURL }}{{ end }}"
+         {{ if .external }}target="_blank" rel="noopener me"{{ end }}>
+        <span class="link-card__icon">{{ partial "helper/icon" .icon }}</span>
+        <span class="link-card__label">{{ .name }}</span>
+        <span class="link-card__chev">{{ partial "helper/icon" "chevron-right" }}</span>
+      </a>
+    {{ end }}
+  </nav>
+</section>
+
+<style>
+.links-page {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 1rem 1rem 2rem;
+}
+.links-profile {
+  text-align: center;
+  padding: 1.5rem 0 2rem;
+}
+.links-avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: var(--shadow-l1, 0 4px 12px rgba(0, 0, 0, 0.12));
+  margin: 0 auto 1rem;
+  display: block;
+}
+.links-name {
+  font-size: 1.5rem;
+  margin: 0 0 .5rem;
+  font-weight: 700;
+}
+.links-bio {
+  margin: 0;
+  color: var(--body-text-color, inherit);
+  opacity: .8;
+  font-size: .95rem;
+}
+.links-list {
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+}
+.link-card {
+  display: flex;
+  align-items: center;
+  gap: .9rem;
+  padding: .95rem 1.15rem;
+  border-radius: 14px;
+  background: var(--card-background, #fff);
+  color: var(--card-text-color-main, inherit);
+  box-shadow: var(--shadow-l1, 0 2px 6px rgba(0, 0, 0, 0.08));
+  text-decoration: none;
+  transition: transform .15s ease, box-shadow .15s ease;
+}
+.link-card:hover,
+.link-card:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-l2, 0 6px 16px rgba(0, 0, 0, 0.14));
+  text-decoration: none;
+}
+.link-card__icon,
+.link-card__chev {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+.link-card__icon svg {
+  width: 1.4rem;
+  height: 1.4rem;
+}
+.link-card__chev {
+  margin-left: auto;
+  opacity: .55;
+}
+.link-card__chev svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+.link-card__label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+</style>
+{{ end }}

--- a/layouts/page/links.html
+++ b/layouts/page/links.html
@@ -12,8 +12,20 @@
 
   <nav class="links-list" aria-label="リンク一覧">
     {{ range .Params.links }}
+      {{- $href := "" -}}
+      {{- if .external -}}
+        {{- $href = .url | safeURL -}}
+      {{- else if eq .url "/" -}}
+        {{- $href = site.Home.RelPermalink -}}
+      {{- else -}}
+        {{- with site.GetPage .url -}}
+          {{- $href = .RelPermalink -}}
+        {{- else -}}
+          {{- $href = .url | relLangURL -}}
+        {{- end -}}
+      {{- end -}}
       <a class="link-card"
-         href="{{ if .external }}{{ .url | safeURL }}{{ else }}{{ .url | relLangURL }}{{ end }}"
+         href="{{ $href }}"
          {{ if .external }}target="_blank" rel="noopener me"{{ end }}>
         <span class="link-card__icon">{{ partial "helper/icon" .icon }}</span>
         <span class="link-card__label">{{ .name }}</span>


### PR DESCRIPTION
## Summary

プレーリーカード的に NFC タグ経由で配れる「リンクまとめページ」を `/page/links/` に追加しました。Linktree 風の縦並びボタン UI で、スマホで開かれた前提のレイアウトです。NFC タグへの書き込みは、生成された URL `https://rin2yh.github.io/blog/page/links/` をスマホアプリ(NFC Tools 等)で書き込めば完成。

掲載リンク(6 つ):
- ブログを読む → `/`
- 自己紹介 / About → `/page/about/`
- GitHub / Twitter (X) / Zenn / Speaker Deck(`menu.toml` の `[[social]]` URL を転記)

## Changes

| 追加ファイル | 役割 |
| --- | --- |
| `content/page/links/index.md` | フロントマターにリンクデータを配列で保持 |
| `layouts/page/links.html` | `layout: "links"` で解決されるカスタムレイアウト。`{{ define "main" }}` で `_default/baseof.html` に組み込み、theme の `partials/helper/icon` でアイコンを inline SVG 化。スコープ限定の `<style>` をレイアウト末尾に同梱 |
| `assets/icons/book.svg` | 「ブログを読む」用(Feather 風) |
| `assets/icons/chevron-right.svg` | カード右端のシェブロン |

既存設定への変更なし(`config/_default/menu.toml`、`params.toml` 等は無変更)。

## デザイン方針

- アバター + 名前 + bio を上部に、その下に角丸ボタンのリンクが縦に並ぶ
- ホバー時に `translateY(-2px)` + 影強調
- テーマの CSS 変数(`--card-background`、`--shadow-l1` 等)を利用し theme 切替に追従
- 外部リンクは新規タブで開き、`rel="noopener me"`(IndieWeb の `me` 関係)
- アイコンは theme 既存(brand-github, brand-twitter, zenn-logo, speakerdeck, user)+ 新規 2 つで賄う

## メニュー登録について

デフォルトでは **メニュー非表示**(NFC / QR / 直リンク経由で来た人だけが見るページ想定)。表示したくなったら `content/page/links/index.md` のフロントマター末尾の `menu:` ブロックのコメントを外すだけで切り替わります。

## Test plan

- [x] ローカルで Hugo 0.154.2 (extended) + Dart Sass 1.97.1 を入れて `hugo --gc --minify` がエラーなく完走
- [x] 生成 HTML を確認: 6 つの `link-card` が render され、内部リンク (`/`, `/page/about/`) と外部リンク (target=_blank rel="noopener me") がそれぞれ正しく出る
- [x] アイコンは全てインライン SVG(`<img>` ではなく `<svg>` 直書き)で render
- [x] CI のビルドジョブが緑
- [ ] マージ後に `https://rin2yh.github.io/blog/page/links/` をスマホで開いて、レイアウト・タップ遷移を確認
- [ ] NFC タグに上記 URL を書き込んで動作確認(リポジトリ外作業)

## ロールバック

`content/page/links/`、`layouts/page/links.html`、`assets/icons/{book,chevron-right}.svg` を消すだけで完全に元の状態に戻ります。設定ファイルに副作用なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WykLro2YEAAmCTmsMmZY48)_