### PR TITLE
fix(links): リンク集の白飛びを修正し bio 文言を整える

### DIFF
--- a/content/page/links/index.md
+++ b/content/page/links/index.md
@@ -6,7 +6,7 @@ description: "りんりんの SNS・ブログなど各種リンク。NFC・QR �
 readingTime: false
 profile:
   name: "りんりん"
-  bio: "ここから各所へどうぞ。ブログ・GitHub・SNS など"
+  bio: "リンク集です"
   avatar: "image/avatar.webp"
 links:
   - name: "ブログを読む"

--- a/layouts/page/links.html
+++ b/layouts/page/links.html
@@ -50,7 +50,7 @@
   height: 96px;
   border-radius: 50%;
   object-fit: cover;
-  box-shadow: var(--shadow-glass, 0 4px 12px rgba(0, 0, 0, 0.28));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.28);
   margin: 0 auto 1rem;
   display: block;
 }
@@ -79,8 +79,8 @@
   background: var(--glass-white, rgba(255, 255, 255, 0.12));
   color: var(--color-text, inherit);
   border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.25));
-  backdrop-filter: var(--blur-md, blur(18px));
   -webkit-backdrop-filter: var(--blur-md, blur(18px));
+  backdrop-filter: var(--blur-md, blur(18px));
   box-shadow: var(--shadow-glass, 0 8px 32px rgba(0, 0, 0, 0.28));
   text-decoration: none;
   transition: transform .15s ease, box-shadow .15s ease, background .2s ease;

--- a/layouts/page/links.html
+++ b/layouts/page/links.html
@@ -50,7 +50,7 @@
   height: 96px;
   border-radius: 50%;
   object-fit: cover;
-  box-shadow: var(--shadow-l1, 0 4px 12px rgba(0, 0, 0, 0.12));
+  box-shadow: var(--shadow-glass, 0 4px 12px rgba(0, 0, 0, 0.28));
   margin: 0 auto 1rem;
   display: block;
 }
@@ -58,11 +58,11 @@
   font-size: 1.5rem;
   margin: 0 0 .5rem;
   font-weight: 700;
+  color: var(--color-text, inherit);
 }
 .links-bio {
   margin: 0;
-  color: var(--body-text-color, inherit);
-  opacity: .8;
+  color: var(--color-text-muted, inherit);
   font-size: .95rem;
 }
 .links-list {
@@ -75,17 +75,21 @@
   align-items: center;
   gap: .9rem;
   padding: .95rem 1.15rem;
-  border-radius: 14px;
-  background: var(--card-background, #fff);
-  color: var(--card-text-color-main, inherit);
-  box-shadow: var(--shadow-l1, 0 2px 6px rgba(0, 0, 0, 0.08));
+  border-radius: var(--radius-md, 14px);
+  background: var(--glass-white, rgba(255, 255, 255, 0.12));
+  color: var(--color-text, inherit);
+  border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.25));
+  backdrop-filter: var(--blur-md, blur(18px));
+  -webkit-backdrop-filter: var(--blur-md, blur(18px));
+  box-shadow: var(--shadow-glass, 0 8px 32px rgba(0, 0, 0, 0.28));
   text-decoration: none;
-  transition: transform .15s ease, box-shadow .15s ease;
+  transition: transform .15s ease, box-shadow .15s ease, background .2s ease;
 }
 .link-card:hover,
 .link-card:focus-visible {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-l2, 0 6px 16px rgba(0, 0, 0, 0.14));
+  background: var(--glass-white-md, rgba(255, 255, 255, 0.2));
+  box-shadow: var(--shadow-float, 0 20px 60px rgba(0, 0, 0, 0.4));
   text-decoration: none;
 }
 .link-card__icon,


### PR DESCRIPTION
## Summary

- `layouts/page/links.html` が旧 Stack テーマの CSS 変数 (`--body-text-color` / `--card-text-color-main` / `--card-background`) を参照していたが、liquid-glass テーマでは未定義のためフォールバックに落ちて **ダークモードで「白カード × 白文字」=白飛び** になっていた。新しいトークン (`--color-text`, `--color-text-muted`, `--glass-white`, `--glass-border`, `--blur-md`, `--shadow-glass` ほか) に差し替え、glass-card 風のスタイルに揃えた。
- `.links-bio` の `opacity: .8` を撤去し、代わりに `--color-text-muted` で muted 表現する（テーマ側で light/dark 両対応済み）。
- bio 文言「ここから各所へどうぞ。ブログ・GitHub・SNS など」が不自然だったため「リンク集です」に変更。

## Test plan

- [ ] `hugo server` でリンク集ページ (`/page/links/`) を開き、ダークモードで本文・カードラベル・bio がきちんと読めることを確認
- [ ] ライトモードに切り替えてもカード/文字色のコントラストが崩れないことを確認
- [ ] カードのホバー（translateY と glass のフェード）が効くことを確認
- [ ] avatar / リンクアイコン / chevron の描画が崩れていないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01B68EtRwtDfAR6iuGPnLeuT)_