### PR TITLE
post: Zenn記事を外部記事リストに追加

### DIFF
--- a/content/post/zenn-9b69cca81875f6-wwxz2rvvmgja48/index.md
+++ b/content/post/zenn-9b69cca81875f6-wwxz2rvvmgja48/index.md
@@ -1,0 +1,8 @@
++++
+date = '2026-05-27T00:00:00+09:00'
+draft = false
+title = 'Zenn 9b69cca81875f6'
+categories = ['tech', 'external']
+tags = ['zenn']
+externalUrl = 'https://zenn.dev/rinrin_yuuki/articles/9b69cca81875f6'
++++

--- a/content/post/zenn-9b69cca81875f6-wwxz2rvvmgja48/index.md
+++ b/content/post/zenn-9b69cca81875f6-wwxz2rvvmgja48/index.md
@@ -1,7 +1,7 @@
 +++
 date = '2026-05-27T00:00:00+09:00'
 draft = false
-title = 'Zenn 9b69cca81875f6'
+title = 'Javaなしで安全に使えるPlantUMLビューア「pumlv」'
 categories = ['tech', 'external']
 tags = ['zenn']
 externalUrl = 'https://zenn.dev/rinrin_yuuki/articles/9b69cca81875f6'


### PR DESCRIPTION
## 概要

Zenn記事を外部記事リスト（`external` カテゴリ）に追加しました。

- 対象記事: https://zenn.dev/rinrin_yuuki/articles/9b69cca81875f6
- 公開日: 2026/05/27
- カテゴリ: `['tech', 'external']`
- タグ: `['zenn']`
- 生成方法: `go run ./cmd/post zenn-9b69cca81875f6 external`（外部記事テンプレート）

追加ファイル: `content/post/zenn-9b69cca81875f6-wwxz2rvvmgja48/index.md`

## 要確認

- **タイトル**: 実行環境のネットワーク許可リストに `zenn.dev` が含まれておらず記事を取得できなかったため、`title` は暫定値 `Zenn 9b69cca81875f6` のままです。実際のタイトルへの差し替えをお願いします。
- ディレクトリ名のスラッグも識別子ベースの暫定値です。必要に応じてリネームしてください。

## Test plan

- [x] `hugo --gc --minify` がエラーなくビルドできること（フロントマターのパースエラーなし）
- [ ] テーマsubmodule初期化後に記事一覧へ正しく表示されること
- [ ] タイトルを実際の記事タイトルに更新

https://claude.ai/code/session_01H4wnVKE5gZFA7CLntLeiXq

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4wnVKE5gZFA7CLntLeiXq)_