### PR TITLE
feat(config): 記事の共有ボタンに X アイコンを設定

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -2,6 +2,9 @@
 mainSections = ["post"]
 rssFullContent = true
 googleAnalytics = "G-M2XSPTPQFB"
+# Icon shown on the article share buttons (sidebar widget + mobile floating action).
+# References assets/icons/brand-twitter.svg (the X logo already bundled for the social link).
+shareIcon = "brand-twitter"
 [footer]
 since = 2026
 customText = ""


### PR DESCRIPTION
## 背景

テーマ `hugo-theme-stack-liquid-glass` の記事共有機能（PC サイドバーの共有ウィジェット + スマホ右下のフローティングボタン）に追従できていなかった。特にスマホの共有ボタンの X アイコンが汎用の外部リンクアイコンになっていた。

テーマ側の仕様を確認した結果:

- **スマホの共有ボタン**（右下 ＋ →「共有」「リンクをコピー」）は `layouts/partials/mobile-actions.html` が記事ページ（`.IsPage`）で**無条件に自動表示**する。`baseof.html` から常に読み込まれるため追加設定は不要。
- **PC サイドバーの共有ウィジェット**は `widgets.page` に `twitter-share` を足すと表示される。→ **本リポジトリでは既に設定済み**（`params.toml` の `widgets.page = ["twitter-share", "toc"]`）。
- 共有アイコンは `helper/share-icon.html` が `site.Params.shareIcon` を読み、`helper/icon` が `resources.Get "icons/<name>.svg"` で解決する。未設定時は汎用の `"external"` アイコンにフォールバックする。

## 変更内容

`config/_default/params.toml` に `shareIcon = "brand-twitter"` を追加した。

- 既にリポジトリに含まれている X ロゴ（`assets/icons/brand-twitter.svg`、ソーシャルリンク用）を再利用し、重複アセットを作らずに済ませた。この SVG の中身は現行の X ロゴそのもの。
- 別名のアイコンを使いたい場合は `assets/icons/` に SVG を置いて `shareIcon` をその名前に変えるだけでよい。

テーマ本体（submodule）は一切編集していない。

## 確認

- `config/_default/*.toml` 全ファイルが正しくパースできることを検証（`tomllib`）。
- `hugo v0.163.3+extended` でローカルビルド（`hugo --gc --minify`）成功。
- 稼働中サイトを Playwright/Chromium で撮影し、実描画を確認:
  - **PC**: サイドバー共有ウィジェットに「共有」見出し＋コピーボタン＋**X ロゴ**ボタンが表示。
  - **スマホ**: 右下 ＋ FAB を押すと「目次」「共有（**X ロゴ**）」「リンクをコピー」が扇状に展開。
  - 共有アイコンが汎用の外部リンクアイコンではなく X ロゴで反映されていることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)