### PR TITLE
fix(post): ブログ改善ログ2が記事一覧に出ない問題を修正

### DIFF
--- a/content/post/2026/blog-enhancement-2-uf6xo3mbhc8bz6/index.md
+++ b/content/post/2026/blog-enhancement-2-uf6xo3mbhc8bz6/index.md
@@ -1,5 +1,5 @@
 +++
-date = '2026-07-03T22:00:00+09:00'
+date = '2026-07-03T12:00:00+09:00'
 draft = false
 title = 'ブログ改善ログ その2'
 slug = 'blog-enhancement-2'


### PR DESCRIPTION
## 概要

「ブログ改善ログ その2」（`content/post/2026/blog-enhancement-2-uf6xo3mbhc8bz6/index.md`）が記事一覧に表示されない問題を修正しました。

## 原因

記事の `date` が `2026-07-03T22:00:00+09:00`（= 13:00 UTC）で、ビルド時点（現在 12:54 JST 前後）から見て **未来日付** になっていました。

Hugo はデフォルトで `buildFuture = false` のため、未来日付の記事をビルド対象から除外します。`config/_default/` 配下に `buildFuture` の設定もないため、この記事だけ公開されていませんでした（`draft = false` は設定済み）。

## 修正内容

- `date` を `2026-07-03T22:00:00+09:00` → `2026-07-03T12:00:00+09:00` に変更し、現在時刻より前の日付にして記事が公開されるようにしました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZwsFiUhmrr8dGtFGd69gr

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZwsFiUhmrr8dGtFGd69gr)_