### PR TITLE
fix(share): X共有でタイトルとURLが渡らない不具合を修正

### DIFF
--- a/layouts/partials/helper/share-url.html
+++ b/layouts/partials/helper/share-url.html
@@ -14,8 +14,12 @@
      title containing a space. Replacing the "+" (only spaces become "+", since
      literal "+" is encoded to %2B) leaves no HTML-special chars in the URL.
 
+  The result is already fully percent-encoded, so it is marked safeURL to
+  declare it safe and stop html/template from re-escaping it in the href
+  attribute (also guards against future Hugo escaping-behaviour changes).
+
   Usage: {{ partial "helper/share-url" . }} where . is a Page.
 */ -}}
 {{- $encoded := printf "%s\n%s" .Title .Permalink | urlquery -}}
 {{- $text := replace $encoded "+" "%20" -}}
-{{- printf "https://x.com/intent/tweet?text=%s" $text -}}
+{{- printf "https://x.com/intent/tweet?text=%s" $text | safeURL -}}

--- a/layouts/partials/helper/share-url.html
+++ b/layouts/partials/helper/share-url.html
@@ -1,0 +1,21 @@
+{{- /*
+  Build the X share-intent URL for a page. Overrides the theme partial.
+
+  Two fixes over the theme default:
+
+  1. Point directly at x.com (not twitter.com): X 301-redirects
+     twitter.com/intent/* to x.com, and that cross-domain redirect drops the
+     query string, so the compose box opens with no text or URL.
+
+  2. Encode spaces as %20, not "+". urlquery emits "+" for spaces; html/template
+     then escapes it to "&#43;", and the href attribute escapes the "&" again to
+     "&amp;#43;". The browser decodes that back to a literal "&", which splits
+     the query string — truncating the title and dropping the permalink for any
+     title containing a space. Replacing the "+" (only spaces become "+", since
+     literal "+" is encoded to %2B) leaves no HTML-special chars in the URL.
+
+  Usage: {{ partial "helper/share-url" . }} where . is a Page.
+*/ -}}
+{{- $encoded := printf "%s\n%s" .Title .Permalink | urlquery -}}
+{{- $text := replace $encoded "+" "%20" -}}
+{{- printf "https://x.com/intent/tweet?text=%s" $text -}}


### PR DESCRIPTION
## 概要

X（Twitter）の共有ボタンを押して遷移した先で、投稿の本文（タイトル）とURLが一切入らなくなっていた不具合を修正します。

テーマ（`stack-liquid-glass` サブモジュール）の `helper/share-url` パーティシャルを、ブログ側の `layouts/partials/helper/share-url.html` で上書きして対応しました（サブモジュール本体は変更していません）。デスクトップのサイドバーウィジェットとモバイルのフローティングボタンの両方が同じパーティシャルを使っているため、1ファイルの上書きで両方に効きます。

## 原因と修正

2つの原因が重なっていました。

**1. `twitter.com` へのリンクによるクエリ欠落（全記事に影響）**
`twitter.com/intent/*` は現在 `x.com` へ301リダイレクトされ、そのクロスドメイン遷移でクエリ文字列が失われます。結果、共有画面が空で開きます。→ 遷移先を最初から `https://x.com/intent/tweet` に変更。

**2. 半角スペースの二重エスケープ（スペースを含むタイトルに影響）**
`urlquery` はスペースを `+` にエンコードしますが、`html/template` がこれを `&#43;` に、さらに `href` 属性のエスケープで `&` が `&amp;` になります。ブラウザは `&amp;` を `&` に戻すため、URL 内で `&` がクエリ区切りと解釈され、スペース以降（＝タイトル後半とパーマリンク）が丸ごと欠落していました（例: `Rails Render`、`HERE Maps API`）。→ スペースを `%20` に置換し、URL に HTML 特殊文字が残らないようにしました。

## 検証

- `hugo`（extended）でサイトをビルドし、生成された `href` を確認。
- スペースを含むタイトルの記事で、`text=…Rails%20Render…%0Ahttps%3A%2F%2F…` のようにタイトルとパーマリンクが両方エンコードされて入ることを確認。
- 生成物全体に `twitter.com/intent`・`&amp;#43;`・生の `+` が残っていないことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXDs8soR9qKqkcMAqH2oKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXDs8soR9qKqkcMAqH2oKh)_