### PR TITLE
スライド追加: なぜGoのカバレッジはstmtとfnなのか

### DIFF
--- a/content/post/why-go-coverage-stmt-fn-c2365ffc337c34/index.md
+++ b/content/post/why-go-coverage-stmt-fn-c2365ffc337c34/index.md
@@ -1,0 +1,8 @@
++++
+date = '2026-07-04T12:57:21+09:00'
+draft = false
+title = 'なぜGoのカバレッジはstmtとfnなのか'
+categories = ['tech', 'external']
+tags = ['slide', 'go']
+externalUrl = 'https://www.docswell.com/s/rin2yh/K277VM-why-does-Go-use-statements-and-functions-for-coverage'
++++


### PR DESCRIPTION
## 概要

外部スライド（Docswell）を他のスライド記事と同様の形式で追加しました。

- タイトル: なぜGoのカバレッジはstmtとfnなのか
- URL: https://www.docswell.com/s/rin2yh/K277VM-why-does-Go-use-statements-and-functions-for-coverage

## 変更内容

- `content/post/why-go-coverage-stmt-fn-c2365ffc337c34/index.md` を追加
  - 既存の外部スライド記事（`effective-go-slide`）と同じく `externalUrl` を指定した external 形式
  - `categories = ['tech', 'external']`, `tags = ['slide', 'go']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPzDib1KoGZu9AygKB5q2c)_