### PR TITLE
Remove note tag from kinoko conference post

### DIFF
--- a/content/post/kinoko2026-bvdksahfjduoin/index.md
+++ b/content/post/kinoko2026-bvdksahfjduoin/index.md
@@ -3,7 +3,7 @@ date = '2026-06-29T22:26:52+09:00'
 draft = false
 title = 'きのこカンファレンス 2026 初参加してみて'
 categories = ['idea']
-tags = ['note', 'conference', 'career']
+tags = ['conference', 'career']
 +++
 
 ## はじめに


### PR DESCRIPTION
## 概要

`note` タグはメモを意味するものではないため、削除しました。

## 変更内容

- `content/post/kinoko2026-bvdksahfjduoin/index.md` の tags から `note` を削除
  - `['note', 'conference', 'career']` → `['conference', 'career']`

`note` タグを使用しているのはこの投稿のみでした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fhFKGZdzsrmsCdeRkrwg9

---
_Generated by [Claude Code](https://claude.ai/code/session_012fhFKGZdzsrmsCdeRkrwg9)_