### PR TITLE
記事内画像をWebP変換・縮小して配信するrender hookを追加

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -11,9 +11,11 @@
 {{- $alt := .PlainText -}}
 {{- $title := .Title -}}
 {{- $img := "" -}}
-{{- $isRemote := or (hasPrefix $dest "http://") (hasPrefix $dest "https://") (hasPrefix $dest "//") -}}
+{{- $u := urls.Parse $dest -}}
+{{- $isRemote := or (ne $u.Scheme "") (ne $u.Host "") -}}
 {{- if not $isRemote -}}
-  {{- with .Page.Resources.Get (strings.TrimPrefix "./" $dest) -}}
+  {{- /* .Path はクエリ・フラグメントを除いたデコード済みパス */ -}}
+  {{- with .Page.Resources.Get (strings.TrimPrefix "./" $u.Path) -}}
     {{- $img = . -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,37 @@
+{{- /*
+  Markdown image render hook.
+
+  ページバンドル内の画像を WebP に変換・縮小して配信する。
+  - 幅 1600px を上限に縮小(Retina 2x 相当)し、800px 幅の srcset も生成
+  - width/height を出力してレイアウトシフト(CLS)を防ぐ
+  - loading="lazy" / decoding="async" で初期表示をブロックしない
+  - SVG / GIF / リモート画像 / バンドル外の画像は変換せずそのまま出力
+*/ -}}
+{{- $dest := .Destination -}}
+{{- $alt := .PlainText -}}
+{{- $title := .Title -}}
+{{- $img := "" -}}
+{{- $isRemote := or (hasPrefix $dest "http://") (hasPrefix $dest "https://") (hasPrefix $dest "//") -}}
+{{- if not $isRemote -}}
+  {{- with .Page.Resources.Get (strings.TrimPrefix "./" $dest) -}}
+    {{- $img = . -}}
+  {{- end -}}
+{{- end -}}
+{{- $processable := false -}}
+{{- if $img -}}
+  {{- $processable = in (slice "jpeg" "png" "webp" "tiff" "bmp") $img.MediaType.SubType -}}
+{{- end -}}
+{{- if $processable -}}
+  {{- $full := $img -}}
+  {{- if gt $img.Width 1600 -}}
+    {{- $full = $img.Resize "1600x webp q80" -}}
+  {{- else if ne $img.MediaType.SubType "webp" -}}
+    {{- $full = $img.Resize (printf "%dx webp q80" $img.Width) -}}
+  {{- end -}}
+  <img src="{{ $full.RelPermalink }}"
+    {{- if gt $img.Width 800 -}}
+      {{- $small := $img.Resize "800x webp q80" }} srcset="{{ $small.RelPermalink }} 800w, {{ $full.RelPermalink }} {{ $full.Width }}w" sizes="(min-width: 1025px) 800px, 100vw"
+    {{- end }} width="{{ $full.Width }}" height="{{ $full.Height }}" loading="lazy" decoding="async" alt="{{ $alt }}"{{ with $title }} title="{{ . }}"{{ end }}>
+{{- else -}}
+  <img src="{{ $dest | safeURL }}" loading="lazy" decoding="async" alt="{{ $alt }}"{{ with $title }} title="{{ . }}"{{ end }}>
+{{- end -}}


### PR DESCRIPTION
## 背景

サイトの表示速度改善の調査で、記事内のMarkdown画像が無加工のまま配信されていることが分かりました。テーマ側にrender-imageフックがないため、例えば [AWS Summit 2024の記事](https://rin2yh.github.io/blog/post/aws-summit2024-1r67hiqe9mublf/) はスマホ撮影のJPG(1.5〜2.3MB × 12枚)をそのまま読み込み、1ページで **約21MB** の画像転送が発生していました。

## 変更内容

`layouts/_default/_markup/render-image.html` を追加(サイト側のlayoutsなのでテーマのサブモジュールには手を入れていません)。

- ページバンドル内の画像を **幅1600px上限でWebP(q80)に変換**(Retina 2x相当)
- **800px幅のsrcset** も生成し、通常表示ではさらに小さい方が選ばれる
- **width/height属性** を出力してレイアウトシフト(CLS)を防止
- **`loading="lazy"` / `decoding="async"`** で初期描画をブロックしない
- SVG / GIF / リモート画像 / バンドル外の画像は従来どおり無加工で出力(フォールバックにもlazyは付与)

## 効果(ローカルで `hugo --gc --minify` を実行して計測)

| ページ | 変更前 | 変更後 |
|---|---|---|
| AWS Summit 2024記事の画像転送量 | 約21MB | 通常表示 約460KB / Retina 2x 約1.1MB |

PNGスクリーンショットを含む他の記事(flutter-crashlytics等)もWebP化されます。既存のCSS(`img { max-width:100%; height:auto }`)があるため、width/height属性を付けても表示は崩れません。

## 確認方法

- `hugo --gc --minify` でビルドが通ること(WebP変換のためextended版が必要。CIはextendedを使用済み)
- 記事ページの`<img>`が`.webp` + `srcset` + `width/height` + `loading=lazy`付きで出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEVaoKcirCrt4i1bxAhYxt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEVaoKcirCrt4i1bxAhYxt)_