### PR TITLE
feat(ogp): 生成OGP画像にサイト名を描画（テーマ0.5.0）

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -5,6 +5,12 @@ googleAnalytics = "G-M2XSPTPQFB"
 # Icon shown on the article share buttons (sidebar widget + mobile floating action).
 # References assets/icons/brand-twitter.svg (the X logo already bundled for the social link).
 shareIcon = "brand-twitter"
+# OGP画像にサイト名（.Site.Title = りんりんのメモ帳）を描画する。
+# テーマ 0.5.0 の新機能。siteNameSince 以降の日付の記事だけに描画され、
+# それより前／日付なしの記事は既存の生成画像のまま変わらない。
+[ogp]
+siteName = true
+siteNameSince = "2026-07-14"
 [footer]
 since = 2026
 customText = ""


### PR DESCRIPTION
## 概要

テーマ側でリリースされた新機能「OGP画像にサイト名を描画」を blog 側で有効化します。今後作る記事の OGP 画像にサイト名（`りんりんのメモ帳`）が入るようになります。

## 変更内容

- **テーマ submodule 更新**: `themes/stack-liquid-glass` を `38d40b7` (0.4.0) → `3074d66` (0.5.0) に更新。0.5.0 に `feat(ogp): draw site name on generated OGP images` が含まれます。
- **設定で機能を有効化** (`config/_default/params.toml`):
  ```toml
  [ogp]
  siteName = true            # .Site.Title（りんりんのメモ帳）をOGP画像左下に描画
  siteNameSince = "2026-07-14"  # 同日以降の日付の記事だけに適用
  ```

## 「今後作る記事」への限定

テーマ 0.5.0 の `siteNameSince` は、指定日より前・日付なしの記事の生成画像を**再生成せず既存のまま**にするためのオプションです。カットオフを本日（2026-07-14）に設定することで、既存の公開済み記事の OGP 画像は変わらず、これから作る記事だけにサイト名が入ります。

## 検証

Hugo extended (v0.164.0) でビルドし、同一タイトル・同一本文で日付だけ異なる記事を生成して OGP 画像を比較:

| 記事の日付 | 機能ON | 機能OFF |
|---|---|---|
| 2026-07-01（カットオフ前） | `…25384262590ee7e0`（サイト名なし） | `…25384262590ee7e0` |
| 2026-07-14（カットオフ以降） | `…bd81bfdad39908e8`（**サイト名あり**） | `…25384262590ee7e0` |

- カットオフ前の記事は機能OFF時とハッシュ一致 → 既存記事の画像はバイト同一で不変
- 2026-07-14 以降の記事のみサイト名オーバーレイが適用される

blog は独自の `assets/ogp/base.png` を持たずテーマ標準を使うため、ベース画像への焼き込みとの二重描画も発生しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KHxdSz2V1MGsGcr46udKH

---
_Generated by [Claude Code](https://claude.ai/code/session_016KHxdSz2V1MGsGcr46udKH)_