### PR TITLE
perf: Speed Insightsのモバイル指摘2件に対応（gtag遅延 / フォント軽量化）

### DIFF
--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -9,22 +9,29 @@
 <script>
   (function () {
     var GA_ID = '{{ . }}';
+    // dataLayer / gtag は即時初期化しておき、gtag.js の読み込み前に
+    // gtag() が呼ばれても ReferenceError にならず dataLayer にキューされるようにする。
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = window.gtag || function () { dataLayer.push(arguments); };
+    gtag('js', new Date());
+    gtag('config', GA_ID);
+
     var started = false;
+    var events = ['scroll', 'mousemove', 'touchstart', 'keydown', 'click'];
     function loadGA() {
       if (started) return;
       started = true;
+      // 発火しなかった分も含め全リスナーを解除する（once では発火分しか外れない）。
+      events.forEach(function (evt) {
+        window.removeEventListener(evt, loadGA);
+      });
       var s = document.createElement('script');
       s.async = true;
       s.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_ID;
       document.head.appendChild(s);
-      window.dataLayer = window.dataLayer || [];
-      window.gtag = function () { dataLayer.push(arguments); };
-      gtag('js', new Date());
-      gtag('config', GA_ID);
     }
-    var events = ['scroll', 'mousemove', 'touchstart', 'keydown', 'click'];
     events.forEach(function (evt) {
-      window.addEventListener(evt, loadGA, { once: true, passive: true });
+      window.addEventListener(evt, loadGA, { passive: true });
     });
     if ('requestIdleCallback' in window) {
       requestIdleCallback(loadGA, { timeout: 5000 });

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,0 +1,36 @@
+{{- /*
+  gtag（Google Analytics）を遅延読み込みする。
+  テーマ同梱版は <script async> で初期表示と同時に gtag.js（約155KiB）を取得するため、
+  PageSpeed Insights で「使用していない JavaScript」として指摘される。
+  最初のユーザー操作、またはブラウザのアイドル時（最大5秒後）まで読み込みを遅らせることで、
+  gtag.js をクリティカルパスから外しつつ計測は維持する。
+*/ -}}
+{{- with .Site.Params.googleAnalytics -}}
+<script>
+  (function () {
+    var GA_ID = '{{ . }}';
+    var started = false;
+    function loadGA() {
+      if (started) return;
+      started = true;
+      var s = document.createElement('script');
+      s.async = true;
+      s.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_ID;
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      window.gtag = function () { dataLayer.push(arguments); };
+      gtag('js', new Date());
+      gtag('config', GA_ID);
+    }
+    var events = ['scroll', 'mousemove', 'touchstart', 'keydown', 'click'];
+    events.forEach(function (evt) {
+      window.addEventListener(evt, loadGA, { once: true, passive: true });
+    });
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(loadGA, { timeout: 5000 });
+    } else {
+      setTimeout(loadGA, 5000);
+    }
+  })();
+</script>
+{{- end -}}

--- a/layouts/partials/head/custom.html
+++ b/layouts/partials/head/custom.html
@@ -1,0 +1,20 @@
+{{- /*
+  サイト側フォント読み込み（テーマ 0.6 以降の head/custom.html フック用）。
+  テーマ本体は Web フォントを一切読み込まないため、必要なフォントはここで持ち込む。
+
+  軽量版：Italiana（見出し・ブランド）/ DM Sans（UI）/ JetBrains Mono（コード）
+  のみを読み込む。重量級の Noto Sans JP（約89KiB）は意図的に外し、本文は
+  --font-body スタックのシステム日本語フォント（BIZ UDPGothic / Hiragino Sans /
+  Yu Gothic 等）にフォールバックさせる。これにより PageSpeed の「未使用の CSS
+  （Google Fonts）」を解消し、モバイルのフォント転送量を最小化する。
+
+  Noto Sans JP を戻して元のタイポグラフィにするには、$href の family リストに
+  "&family=Noto+Sans+JP:wght@400;500;700" を追加する。
+
+  media="print" → onload の切り替えで非同期に読み込み、初回描画をブロックしない。
+*/ -}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+{{- $href := "https://fonts.googleapis.com/css2?family=Italiana&family=DM+Sans:wght@400;500&family=JetBrains+Mono:wght@400;600&display=swap" -}}
+<link rel="stylesheet" href="{{ $href }}" media="print" onload="this.media='all'">
+<noscript><link rel="stylesheet" href="{{ $href }}"></noscript>


### PR DESCRIPTION
## 背景

PageSpeed Insights（携帯電話）で2件の指摘が出ていた。スマホ版で遅い、という状況への対応。

| # | 指摘 | 内容 | 対応 |
|---|---|---|---|
| ① | 使用していない JavaScript | Google Tag Manager `gtag/js`（155.1 KiB / 65 KiB削減可）▲高優先度 | gtagを遅延読み込み |
| ② | 未使用の CSS | Google Fonts `css2?family=...`（89.6 KiB、大半が Noto Sans JP） | フォントを軽量セットに |

## 変更内容

### ① gtag.js の遅延読み込み（`layouts/partials/head/google-analytics.html`）

テーマ同梱パーシャルをプロジェクト側で上書き。従来は初期表示と同時に約155 KiB を取得していたが、**最初のユーザー操作**（scroll / mousemove / touchstart / keydown / click）または **`requestIdleCallback`（最大5秒フォールバック）** まで読み込みを遅延し、クリティカルパスから外す。

- `dataLayer` / `gtag` は即時初期化してあり、遅延ロード前に `gtag()` が呼ばれても `ReferenceError` にならずキューされる。
- `loadGA` 発火時に全イベントリスナーを明示的に解除（`once:true` は発火分しか外れないため）。
- 計測（`gtag('config', ...)`）は従来どおり維持。

### ② フォントの軽量化（`layouts/partials/head/custom.html` + テーマ v0.5.2）

テーマ v0.5.2（#72）で**テーマ本体は Web フォントを一切読み込まず、サイト側の `head/custom.html` フックで持ち込む**破壊的変更が入った。これに合わせて：

- submodule を v0.5.1 → **v0.5.2** に更新。
- サイト側 `head/custom.html` で **Italiana / DM Sans(400;500) / JetBrains Mono(400;600)** のみを非同期読み込み（`media=print`→`onload`）。
- **約89 KiB の Noto Sans JP を外す**。本文は `--font-body` スタックのシステム日本語フォント（BIZ UDPGothic / Hiragino Sans / Yu Gothic 等）にフォールバック。
- これにより PageSpeed の「未使用の CSS（Google Fonts）」は構造的に解消し、モバイルのフォント転送量を最小化。見出し（Italiana）・UI（DM Sans）・コード（JetBrains Mono）のデザインは維持され、変わるのは本文フォントのみ。

Noto Sans JP を戻して元のタイポグラフィにしたい場合は、`custom.html` の `$href` に `&family=Noto+Sans+JP:wght@400;500;700` を足すだけ。

## 検証

`hugo v0.164.0+extended` 本番ビルド（`--environment production --minify`）で確認：

- **① gtag**：eager な `<script async src=".../gtag/js">` が消え、遅延スクリプトが `?id=G-M2XSPTPQFB`（引用符崩れなし）を組み立て、`requestIdleCallback` フォールバックとリスナー登録が出力されること。
- **② フォント**：v0.5.2 + custom.html で css2 リンクが Italiana/DM Sans/JetBrains Mono の1本のみ・**Noto Sans JP は0件**、非同期パターン（`media=print`/`onload`）維持。
- v0.5.1→v0.5.2 の差分は `head.html` のフォント方式のみで他への影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)