### PR TITLE
fix(pwa): ドメイン移行に合わせて manifest に start_url / scope / id を追加

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,16 +1,21 @@
 {
   "name": "りんりんのメモ帳",
   "short_name": "りんりんのメモ帳",
+  "id": "/",
+  "start_url": "/",
+  "scope": "/",
   "icons": [
     {
-      "src": "android-chrome-192x192.png",
+      "src": "/android-chrome-192x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
-      "src": "android-chrome-512x512.png",
+      "src": "/android-chrome-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     }
   ],
   "theme_color": "#ffffff",


### PR DESCRIPTION
## 背景

ドメインを `https://rin2yh.github.io/blog/`（サブパス配信）から `https://rin2yh.com/`（ルートドメイン）へ移行しました（コミット `5900fea`）。

一方で PWA の Web App Manifest（`static/site.webmanifest`）は移行前から一度も更新されておらず、`start_url` / `scope` / `id` が無い最小構成のままでした。この状態だとルートドメインでのインストール可否・アプリ識別が不安定になります。

## 変更内容

`static/site.webmanifest` を修正しました。

- `start_url` / `scope` / `id` を `"/"` で明示し、ルートドメインで確実にインストール・識別できるようにする
- アイコンの `src` をルート相対パス（`/android-chrome-*.png`）にして、解決先を一意にする
- `icons` に `purpose: "any"` を明示

## 補足（利用者側の対応）

すでにホーム画面に追加済みの PWA は、**旧オリジン（`rin2yh.github.io/blog/`）に scope が固定されています**。ドメイン移行後は旧 URL が新ドメインへリダイレクトされ、scope 外に出るためスタンドアロン表示にならず「アプリとして開けない」状態になります。

一度旧アイコンを削除し、`https://rin2yh.com/` から **再インストール（ホーム画面に追加）** し直してください。今回の manifest 修正は再インストール後の挙動を正すものです。

## 確認

- `site.webmanifest` の JSON 妥当性を確認済み
- アイコン実体（192x192 / 512x512 PNG）が `static/` に存在することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL5EH3MmRBK2jQrAarMoDu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL5EH3MmRBK2jQrAarMoDu)_