### PR TITLE
docs(about): 自己紹介に「作ったもの」セクションを追加する

### DIFF
--- a/content/page/about/index.md
+++ b/content/page/about/index.md
@@ -2,7 +2,7 @@
 title: 自己紹介
 description: 過去の経歴などをまとめています。
 date: 2026-01-30
-lastmod: 2026-01-30
+lastmod: 2026-08-04
 readingTime: false
 menu:
   main:
@@ -43,6 +43,14 @@ menu:
     - マーケティングチーム　リーダー（2021.01 - 2021.03）
     - オンラインAIコース　兼任（2021.01 - 2023.07）
 {{< /details >}}
+
+
+## 作ったもの
+
+- [ゲーム集](https://games.rin2yh.com/)
+    - 個人開発で作ったゲームを置いているサイト
+- [スライド置き場](https://slides.rin2yh.com/)
+    - 登壇資料をまとめているサイト
 
 
 ## 趣味


### PR DESCRIPTION
## 概要

ゲーム集（https://games.rin2yh.com/ ）をブログのどこかに載せたい、という相談への対応です。

サイドバーの social リンク（RSS / GitHub / Twitter / Zenn / Slides）は既に5つあり、6つ目を足すと重くなるため、自己紹介ページに「作ったもの」セクションを新設してそこにまとめました。

## 変更内容

- `content/page/about/index.md`
  - 「経歴」と「趣味」の間に `## 作ったもの` を追加
  - ゲーム集（games.rin2yh.com）とスライド置き場（slides.rin2yh.com）を掲載
  - `lastmod` を更新

## 補足

- スライド置き場はサイドバーにも既にリンクがありますが、「作ったもの」として並べたほうが自然なので同じセクションに入れています。不要であれば削ってください。
- ゲーム集の説明文（「個人開発で作ったゲームを置いているサイト」）は仮置きです。サイトの中身を直接確認できなかったため、実態に合わせて書き換えてもらえると助かります。
- `content/page/about/index.md` は `.textlintignore` の対象なので textlint は走りません。

---
_Generated by [Claude Code](https://claude.ai/code/session_014S6SUquor4ah1mPbJRgLE7)_